### PR TITLE
feat: add audio volume and mute control for video player

### DIFF
--- a/src/raylib_media.nim
+++ b/src/raylib_media.nim
@@ -4,8 +4,8 @@ import std/[options]
 import pkg/raylib
 import raylib_media/bindings
 
-proc newMediaStream*(file: string, flags: set[MediaLoadFlag] = {}): Option[MediaStream] {.inline.} =
-  var media = LoadMediaEx(file.cstring(), cast[int32](flags))
+proc newMediaStream*(file: string, flags: set[MediaLoadFlag] = {}, volume: float32 = 1.0): Option[MediaStream] {.inline.} =
+  var media = LoadMediaEx(file.cstring(), cast[int32](flags), volume)
 
   if IsMediaValid(media):
     return some(move(media))
@@ -36,6 +36,21 @@ func `position=`*(media: var MediaStream, time: float32): bool {.inline, discard
 
 func position*(media: MediaStream): float32 {.inline, discardable.} =
   GetMediaPosition(media)
+
+func `volume=`*(media: var MediaStream, volume: float32): bool {.inline, discardable.} =
+  SetMediaVolume(media, volume)
+
+func volume*(media: MediaStream): float32 {.inline, discardable.} =
+  GetMediaVolume(media)
+
+func mute*(media: var MediaStream, flag: bool): bool {.inline, discardable.} =
+  if flag:
+    return MuteMedia(media)
+  else:
+    return UnmuteMedia(media)
+
+func isMuted*(media: MediaStream): bool {.inline.} =
+  IsMediaMuted(media)
 
 func mediaProperties*(media: MediaStream): MediaProperties {.inline.} =
   GetMediaProperties(media)

--- a/src/raylib_media/bindings.nim
+++ b/src/raylib_media/bindings.nim
@@ -86,11 +86,11 @@ proc LoadMedia*(fileName: cstring): MediaStream
   ## Load a `MediaStream` from a file.
   ## Returns an empty `MediaStream` on failure.
 
-proc LoadMediaEx*(fileName: cstring, flags: int32): MediaStream
+proc LoadMediaEx*(fileName: cstring, flags: int32, volume: float32): MediaStream
   ## Load a `MediaStream` from a file with flags.
   ## Returns an empty `MediaStream` on failure.
 
-proc LoadMediaFromStream*(streamReader: MediaStreamReader, flags: int32)
+proc LoadMediaFromStream*(streamReader: MediaStreamReader, flags: int32, volume: float32): MediaStream
   ## Load a `MediaStream` from a custom stream with flags.
   ## Returns an empty `MediaStream` on failure.
 
@@ -113,6 +113,17 @@ proc SetMediaState*(mediaStream: MediaStream, newState: int32): int32
 proc GetMediaPosition*(mediaStream: MediaStream): float32
 
 proc SetMediaPosition*(mediaStream: MediaStream, timeSec: float32): bool
+
+proc GetMediaVolume*(mediaStream: MediaStream): float32
+
+proc SetMediaVolume*(mediaStream: MediaStream, volume: float32): bool
+
+proc MuteMedia*(mediaStream: MediaStream): bool
+
+proc UnmuteMedia*(mediaStream: MediaStream): bool
+
+proc IsMediaMuted*(mediaStream: MediaStream): bool
+  ## Check if a `MediaStream` is muted.
 
 proc SetMediaLooping*(mediaStream: MediaStream, loopPlay: bool): bool
 

--- a/src/raylib_media/raymedia.h
+++ b/src/raylib_media/raymedia.h
@@ -170,17 +170,19 @@ extern "C" {
      * Load a MediaStream from a file with flags.
      * @param fileName Path to the movie file
      * @param flags Combination of MediaLoadFlag values
+     * @param volume Volume level (0.0 to 1.0). Default is 1.0
      * @return MediaStream on success; empty structure on failure
      */
-    RLAPI MediaStream LoadMediaEx(const char* fileName, int flags);
+    RLAPI MediaStream LoadMediaEx(const char* fileName, int flags, double volume);
 
     /**
      * Load a MediaStream from a custom stream with flags.
      * @param streamReader A valid MediaStreamReader with callback functions and context
      * @param flags Combination of MediaLoadFlag values
+     * @param volume Volume level (0.0 to 1.0). Default is 1.0
      * @return MediaStream on success; empty structure on failure
      */
-    RLAPI MediaStream LoadMediaFromStream(MediaStreamReader streamReader, int flags);
+    RLAPI MediaStream LoadMediaFromStream(MediaStreamReader streamReader, int flags, double volume);
 
     /**
      * Check if a MediaStream is valid (loaded and initialized).
@@ -240,6 +242,42 @@ extern "C" {
      * @return true on success; false otherwise
      */
     RLAPI bool SetMediaPosition(MediaStream media, double timeSec);
+
+    /**
+     * Get the volume of a MediaStream.
+     * @param media A valid MediaStream
+     * @return Volume level; negative on failure
+     */
+    RLAPI double GetMediaVolume(MediaStream media);
+
+    /**
+     * Set the volume of a MediaStream.
+     * @param media A valid MediaStream
+     * @param volume Volume level (0.0 to 1.0)
+     * @return true on success; false otherwise
+     */
+    RLAPI bool SetMediaVolume(MediaStream media, double volume);
+
+    /**
+     * Mute a MediaStream.
+     * @param media A valid MediaStream
+     * @return true on success; false otherwise
+     */
+    RLAPI bool MuteMedia(MediaStream media);
+
+    /**
+     * Unmute a MediaStream.
+     * @param media A valid MediaStream
+     * @return true on success; false otherwise
+     */
+    RLAPI bool UnmuteMedia(MediaStream media);
+
+    /**
+     * Check if a MediaStream is muted.
+     * @param media A valid MediaStream
+     * @return true if muted; false otherwise
+     */
+    RLAPI bool IsMediaMuted(MediaStream media);
 
     /**
      * Enable or disable loop playback for a MediaStream.

--- a/src/raylib_media/rmedia.c
+++ b/src/raylib_media/rmedia.c
@@ -185,6 +185,8 @@ typedef struct MediaContext
 	MediaState state;                           // Current state of the media. Use SetMediaState()/GetMediaState() to modify.
 	double timePos;                             // Current playback position in seconds
 	bool loopPlay;                              // Indicates if the media plays in a loop. Use SetMediaLooping() to set.
+	double volume;                              // Volume level for the media stream (0.0 to 1.0). Use SetMediaVolume() to set.
+	double storedVolume;                        // Stored volume level for the media stream (0.0 to 1.0) used for restoring the audio level.
 } MediaContext;
 
 
@@ -319,8 +321,9 @@ void AVUnloadCodecContext(StreamDataContext* streamCtx);
 // - fileName: Name of the media file to load. Ignored if a valid MediaStreamReader is provided.
 // - streamReader: A MediaStreamReader containing custom IO callbacks. Takes precedence over fileName if valid.
 // - flags: Combination of MediaLoadFlag values to configure loading behavior.
+// - volume: Volume level for the media stream (0.0 to 1.0). Default is 1.0.
 // Returns: Pointer to the allocated MediaContext on success, or NULL on failure.
-MediaContext* LoadMediaContext(const char* fileName, MediaStreamReader streamReader, int flags);
+MediaContext* LoadMediaContext(const char* fileName, MediaStreamReader streamReader, int flags, double volume);
 
 void UnloadMediaContext(MediaContext* ctx);
 
@@ -526,6 +529,67 @@ double GetMediaPosition(MediaStream media)
 	return pos;
 }
 
+bool SetMediaVolume(MediaStream media, double volume)
+{
+    if (!IsMediaValid(media))
+    {
+        TraceLog(LOG_WARNING, "MEDIA: Trying to set volume on an invalid media.");
+        return false;
+    }
+
+	volume = CLAMP(volume, 0.0, 1.0);
+
+	if (volume > 0.0) {
+		media.ctx->storedVolume = volume;
+	}
+
+    media.ctx->volume = volume;
+    return true;
+}
+
+double GetMediaVolume(MediaStream media)
+{
+    if(!IsMediaValid(media))
+    {
+        TraceLog(LOG_WARNING, "MEDIA: Trying to get volume of an invalid media.");
+        return -1.0f;
+    }
+    return media.ctx->volume;
+}
+
+bool MuteMedia(MediaStream media) {
+    if (!IsMediaValid(media)) {
+        TraceLog(LOG_WARNING, "MEDIA: Trying to mute an invalid media.");
+        return false;
+    }
+
+	if (media.ctx->volume > 0.0) {
+		media.ctx->storedVolume = media.ctx->volume;
+	}
+	media.ctx->volume = 0.0;
+
+    return true;
+}
+
+bool UnmuteMedia(MediaStream media) {
+    if (!IsMediaValid(media)) {
+        TraceLog(LOG_WARNING, "MEDIA: Trying to unmute an invalid media.");
+        return false;
+    }
+
+    media.ctx->volume = CLAMP(media.ctx->storedVolume, 0.0, 1.0);
+    return true;
+}
+
+bool IsMediaMuted(MediaStream media) {
+	if (!IsMediaValid(media)) {
+        TraceLog(LOG_WARNING, "MEDIA: Trying to check if media is muted.");
+        return false;
+    }
+
+	return media.ctx->volume <= 0.0;
+}
+
 bool SetMediaLooping(MediaStream media, bool loopPlay)
 {
 	int ret = false;
@@ -548,13 +612,15 @@ bool SetMediaLooping(MediaStream media, bool loopPlay)
 // Functions Definition - Media Context loading and unloading
 //---------------------------------------------------------------------------------------------------
 
-MediaContext* LoadMediaContext(const char* fileName, MediaStreamReader streamReader, int flags)
+MediaContext* LoadMediaContext(const char* fileName, MediaStreamReader streamReader, int flags, double volume)
 {
 	MediaContext* ctx = (MediaContext*) RL_MALLOC(sizeof(MediaContext));
 
 	*ctx = (MediaContext){ 0 };
 
 	ctx->state = MEDIA_STATE_INVALID;
+	ctx->volume = CLAMP(volume, 0.0, 1.0);
+	ctx->storedVolume = ctx->volume;
 
 	ctx->formatContext = avformat_alloc_context();
 
@@ -1002,16 +1068,16 @@ MediaStream LoadMediaFromContext(MediaContext *ctx, int flags)
 
  MediaStream LoadMedia(const char* fileName)
  {
-	 return LoadMediaEx(fileName, MEDIA_LOAD_AV);
+	 return LoadMediaEx(fileName, MEDIA_LOAD_AV, 1.0);
  }
 
- MediaStream LoadMediaEx(const char* fileName, int flags)
+ MediaStream LoadMediaEx(const char* fileName, int flags, double volume)
  {
-	 MediaContext* ctx = LoadMediaContext(fileName, (MediaStreamReader) { 0 }, flags);
+	 MediaContext* ctx = LoadMediaContext(fileName, (MediaStreamReader) { 0 }, flags, volume);
 	 return LoadMediaFromContext(ctx, flags);
  }
 
- MediaStream LoadMediaFromStream(MediaStreamReader streamReader, int flags)
+ MediaStream LoadMediaFromStream(MediaStreamReader streamReader, int flags, double volume)
  {
 	 if (!streamReader.readFn)
 	 {
@@ -1019,7 +1085,7 @@ MediaStream LoadMediaFromContext(MediaContext *ctx, int flags)
 		 return (MediaStream) { 0 }; 
 	 }
 
-	 MediaContext* ctx = LoadMediaContext(NULL, streamReader, flags); 
+	 MediaContext* ctx = LoadMediaContext(NULL, streamReader, flags, volume);
 	 return LoadMediaFromContext(ctx, flags); 
  }
 
@@ -1972,6 +2038,53 @@ int  AVProcessVideoFrame(const MediaStream* media)
 	return 0;
 }
 
+static void ApplyVolumeScaling(void* outputBuffer, int convertedSamples, const MediaStream* media) {
+    MediaContext* ctx = media->ctx;
+    switch (ctx->audioOutputFmt) {
+        case AV_SAMPLE_FMT_S16:
+        {
+            int16_t* samples = (int16_t*)outputBuffer;
+            int totalSamples = convertedSamples * media->audioStream.channels;
+            for (int i = 0; i < totalSamples; i++) {
+                float adjusted = samples[i] * ctx->volume;
+				samples[i] = (int16_t) CLAMP(adjusted, (float)INT16_MIN, (float)INT16_MAX);
+            }
+        }
+        break;
+        case AV_SAMPLE_FMT_S32:
+        {
+            int32_t* samples = (int32_t*)outputBuffer;
+            int totalSamples = convertedSamples * media->audioStream.channels;
+            for (int i = 0; i < totalSamples; i++) {
+                float adjusted = samples[i] * ctx->volume;
+				samples[i] = (int32_t) CLAMP(adjusted, (float)INT32_MIN, (float)INT32_MAX);
+            }
+        }
+        break;
+        case AV_SAMPLE_FMT_FLT:
+        {
+            float* samples = (float*)outputBuffer;
+            int totalSamples = convertedSamples * media->audioStream.channels;
+            for (int i = 0; i < totalSamples; i++) {
+                samples[i] *= ctx->volume;
+            }
+        }
+        break;
+        case AV_SAMPLE_FMT_DBL:
+        {
+            double* samples = (double*)outputBuffer;
+            int totalSamples = convertedSamples * media->audioStream.channels;
+            for (int i = 0; i < totalSamples; i++) {
+                samples[i] *= ctx->volume;
+            }
+        }
+        break;
+        default:
+            TraceLog(LOG_WARNING, "MEDIA: Volume scaling for unsupported audio format.");
+            break;
+    }
+}
+
 int  AVProcessAudioFrame(const MediaStream* media)
 {
 	MediaContext* ctx = media->ctx;
@@ -2028,6 +2141,9 @@ int  AVProcessAudioFrame(const MediaStream* media)
 			ctx->audioOutputFmt,
 			1
 		);
+
+		// Apply volume scaling to the converted samples in the output buffer.
+		ApplyVolumeScaling(outputBuffer, convertedSamples, media);
 
 		AdvanceWritePosN(&ctx->audioOutputBuffer.state, convertedSamplesBytes);
 

--- a/tests/test2.nim
+++ b/tests/test2.nim
@@ -12,7 +12,8 @@ proc main =
   setTargetFPS(144)
   initAudioDevice()
 
-  let oStream = newMediaStream(param)
+  # Volume param is optional, default is 1.0f
+  let oStream = newMediaStream(file=param, volume=0.5f)
   if oStream.isNone:
     quit "Failed to load media file: " & param
     
@@ -21,7 +22,7 @@ proc main =
 
   while not windowShouldClose():
     stream.update()
-    echo stream.position
+    echo stream.position, " ", stream.volume
 
     if isKeyPressed(Left):
       stream.position = stream.position - 10f
@@ -32,6 +33,16 @@ proc main =
     if isKeyPressed(Space):
       stream.state = (if stream.state == MediaState.Paused: MediaState.Playing else: MediaState.Paused)
       stream.update()
+
+    if isKeyPressed(M):
+      let isMuted = not stream.isMuted
+      discard stream.mute(isMuted)
+
+    if isKeyPressed(Up):
+      stream.volume = stream.volume + 0.1f
+
+    if isKeyPressed(Down):
+      stream.volume = stream.volume - 0.1f
 
     drawing:
       clearBackground(RayWhite)


### PR DESCRIPTION
### Overview

Added audio volume control along with integrated mute/unmute functionality. This enhancement allows users to adjust the audio level during playback, as well as toggle mute state without interrupting the video stream.

### Key Changes

- **Volume Control:**  
  Implemented functions to set and get the audio volume. Volume values are clamped between 0.0 (mute) and 1.0 (full volume).
 
- **Mute/Unmute Feature:**  
  Added dedicated functions (`MuteMedia` and `UnmuteMedia`) to handle mute state. When muting, the current volume is stored in a backup field (named `storedVolume`), and restored upon unmuting.

- **API Improvements:**  
  Extended the public API with functions like `SetMediaVolume`, `MuteMedia`, `UnmuteMedia`, and `IsMediaMuted`.
  
- **Internal Refactoring:**  
  Introduced an inline helper (`ApplyVolumeScaling`) that uses a streamlined clamping mechanism, which simplifies the per-sample volume adjustment process.

### Testing

- Updated `test2.nim` to include scenarios for adjusting volume, muting, and unmuting.
